### PR TITLE
Fix to issue #2

### DIFF
--- a/index.js
+++ b/index.js
@@ -165,7 +165,7 @@
    * @api private
    */
   function isFunction (value) {
-    return toString.call(value) === funcClass
+    return Object.prototype.toString.call(value) === funcClass
   }
   var funcClass = '[object Function]'
 


### PR DESCRIPTION
In IE browsers, the toString.call(value) would fail for the browser implementation of the window.toString function, as explained in  http://stackoverflow.com/questions/19321938/invalid-calling-object-error-in-ie. Now it is bound to the Object prototype instead.